### PR TITLE
Don't generate unnecessary debugging output when obtaining file lock.

### DIFF
--- a/lib/cPanel/StateFile/FileLocker.pm
+++ b/lib/cPanel/StateFile/FileLocker.pm
@@ -75,9 +75,6 @@ sub file_lock {
             return $lockfile;
         }
 
-        # Unable to create the lockfile.
-        $self->_info('Unable to create the lockfile, waiting');
-
         while ( $deadline > time ) {
             my ( $pid, $name, $max_time ) = $self->_read_lock_file($lockfile);
             unless ($pid) {


### PR DESCRIPTION
Case CPANEL-3878: Don't generate unneeded debugging output when
obtaining file lock.