### PR TITLE
Remove Version section from Pod.

### DIFF
--- a/lib/cPanel/StateFile.pod
+++ b/lib/cPanel/StateFile.pod
@@ -3,10 +3,6 @@
 
 cPanel::StateFile - Standardize the handling of file-based state data.
 
-=head1 VERSION
-
-This document describes cPanel::StateFile 0.700
-
 =head1 SYNOPSIS
 
     use cPanel::StateFile;

--- a/lib/cPanel/StateFile/FileLocker.pod
+++ b/lib/cPanel/StateFile/FileLocker.pod
@@ -3,12 +3,6 @@
 
 cPanel::StateFile::FileLocker - Lock and unlock files using C<flock>.
 
-
-=head1 VERSION
-
-This document describes cPanel::StateFile::FileLocker version 0.700
-
-
 =head1 SYNOPSIS
 
     use cPanel::StateFile::FileLocker;

--- a/lib/cPanel/TaskQueue.pod
+++ b/lib/cPanel/TaskQueue.pod
@@ -3,10 +3,6 @@
 
 cPanel::TaskQueue - FIFO queue of tasks to perform
 
-=head1 VERSION
-
-This document describes cPanel::TaskQueue version 0.700
-
 =head1 SYNOPSIS
 
     use cPanel::TaskQueue ();

--- a/lib/cPanel/TaskQueue/ChildProcessor.pod
+++ b/lib/cPanel/TaskQueue/ChildProcessor.pod
@@ -3,10 +3,6 @@
 
 cPanel::TaskQueue::ChildProcessor - Processes an individual task from the cPanel::TaskQueue in a child process.
 
-=head1 VERSION
-
-This document describes cPanel::TaskQueue::ChildProcessor version 0.700.
-
 =head1 SYNOPSIS
 
     package NewTask;

--- a/lib/cPanel/TaskQueue/Ctrl.pod
+++ b/lib/cPanel/TaskQueue/Ctrl.pod
@@ -3,11 +3,6 @@
 
 cPanel::TaskQueue::Ctrl - A text-based interface for controlling a TaskQueue
 
-=head1 VERSION
-
-This document describes cPanel::TaskQueue::Ctrl version 0.700
-
-
 =head1 SYNOPSIS
 
     use cPanel::TaskQueue::Ctrl;

--- a/lib/cPanel/TaskQueue/PluginManager.pod
+++ b/lib/cPanel/TaskQueue/PluginManager.pod
@@ -3,10 +3,6 @@
 
 cPanel::TaskQueue::PluginManager - Supplies support for loading the Queue task processing plugins.
 
-=head1 VERSION
-
-This document describes C<cPanel::TaskQueue::PluginManager> version 0.700.
-
 =head1 SYNOPSIS
 
    use cPanel::TaskQueue::PluginManager;

--- a/lib/cPanel/TaskQueue/Processor.pod
+++ b/lib/cPanel/TaskQueue/Processor.pod
@@ -3,10 +3,6 @@
 
 cPanel::TaskQueue::Processor - Processes an individual task from the cPanel::TaskQueue.
 
-=head1 VERSION
-
-This document describes cPanel::TaskQueue::Processor version 0.700.
-
 =head1 SYNOPSIS
 
     package NewTask;

--- a/lib/cPanel/TaskQueue/Scheduler.pod
+++ b/lib/cPanel/TaskQueue/Scheduler.pod
@@ -3,10 +3,6 @@
 
 cPanel::TaskQueue::Scheduler - Priority queue of Tasks to Queue at some time in the future.
 
-=head1 VERSION
-
-This document describes cPanel::TaskQueue::Scheduler version 0.700.
-
 =head1 SYNOPSIS
 
     use cPanel::TaskQueue;

--- a/lib/cPanel/TaskQueue/Task.pod
+++ b/lib/cPanel/TaskQueue/Task.pod
@@ -3,10 +3,6 @@
 
 cPanel::TaskQueue::Task - Objects representing the task concept.
 
-=head1 VERSION
-
-This document describes cPanel::TaskQueue::Task version 0.700.
-
 =head1 SYNOPSIS
 
     use cPanel::TaskQueue;


### PR DESCRIPTION
The VERSION sections in the Pod report that they are explicitly for
0.700.  Hopefully, they are updated as the code they refer to changes.
Since Dist::Zilla does not update these entries, and maintaining them is
a chore, remove these sections.