### PR TITLE
Reduce default wait time between lock checks in queueprocd

### DIFF
--- a/lib/cPanel/StateFile/FileLocker.pod
+++ b/lib/cPanel/StateFile/FileLocker.pod
@@ -49,7 +49,7 @@ should be significantly less than the I<max_wait> value. The default value is
 
 The number of seconds to sleep between attempts to check the lock file. Higher
 numbers reduce CPU and disk load, but reduce responsiveness. The default value
-is the lowest allowed, 1.
+is 0.1. The lowest allowed value is 0.05.
 
 =back
 

--- a/t/statefile_filelocker_new.t
+++ b/t/statefile_filelocker_new.t
@@ -21,7 +21,7 @@ like( $@, qr/Required logger/, 'Missing logger parameter' );
 my $locker = cPanel::StateFile::FileLocker->new( {max_age=>120, max_wait=>180, logger=>cPanel::FakeLogger->new()} );
 isa_ok( $locker, 'cPanel::StateFile::FileLocker', 'with_hashref' );
 
-$locker = cPanel::StateFile::FileLocker->new( {sleep_secs=>0.1, logger=>cPanel::FakeLogger->new()} );
+$locker = cPanel::StateFile::FileLocker->new( {sleep_secs=>0.001, logger=>cPanel::FakeLogger->new()} );
 isa_ok( $locker, 'cPanel::StateFile::FileLocker', 'with_hashref and subsecond sleep attempt' );
 # Peek inside for test, don't try this at home.
-is( $locker->{sleep_secs}, 1, 'Sub-second sleep repaired.' );
+is( $locker->{sleep_secs}, 0.05, 'Sleep less then 0.05 repaired.' );


### PR DESCRIPTION
case CPANEL-8047

When cPanel::StateFile was orignally written 1s was an acceptable
wait time to process the next item in the queue.  As CPUs have
become faster we needed to lower this.