### PR TITLE
Avoid a SEGV during global destruction

### DIFF
--- a/lib/cPanel/TaskQueue.pm
+++ b/lib/cPanel/TaskQueue.pm
@@ -103,12 +103,13 @@ sub _first (&@) {                                      ## no critic(ProhibitSubr
 # Namespace string used when creating task ids.
 my $taskqueue_uuid = 'TaskQueue';
 
-{
+# Class-wide definition of the valid processors
+my %valid_processors;
+END { undef %valid_processors } # case CPANEL-10871 to avoid a SEGV during global destruction
 
-    # Class-wide definition of the valid processors
-    my %valid_processors;
-    my $FILETYPE      = 'TaskQueue';    # Identifier at the beginning of the state file
-    my $CACHE_VERSION = 3;              # Cache file version number.
+{
+   my $FILETYPE      = 'TaskQueue';    # Identifier at the beginning of the state file
+   my $CACHE_VERSION = 3;              # Cache file version number.
 
     # State File
     #


### PR DESCRIPTION
Case CPANEL-10871:

There is an order issue during global destruction
when the module is loaded at run time.
Forcing to clear manually all the tasks just before
global destruction avoid a segfault where we call
DESTROY from a stash already destroyed...