### PR TITLE
Bump version to 0.850

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = cPanel-TaskQueue
-version = 0.800
+version = 0.850
 author  = cPanel, Inc. <cpan@cpanel.net>
 license = Perl_5
 copyright_holder = cPanel, Inc.


### PR DESCRIPTION
This bumps the version number so we can do a new release.  However, dzil test fails at the moment (I believe due to 9d61011e5c6a03eda112378c88bf2faed40c5358), so we can't make a release yet.

I'll do a new release once the testsuite passes completely.