### PR TITLE
Atomic writes

### DIFF
--- a/lib/cPanel/StateFile.pm
+++ b/lib/cPanel/StateFile.pm
@@ -223,7 +223,7 @@ sub import {
         }
 
         sub _open {
-            my ( $self, $mode ) = @_;
+            my ( $self ) = @_;
             my $state_file = $self->{state_file};
             $state_file->throw('Cannot open state file inside a call_unlocked call.') unless defined $self->{lock_file};
 
@@ -269,7 +269,7 @@ sub import {
             $state_file->throw('Cannot update_file inside a call_unlocked call.') unless defined $self->{lock_file};
 
             if ( !$state_file->{file_handle} ) {
-                $self->_open('+<');
+                $self->_open();
             }
 
             #Set UNLINK in case we die().
@@ -447,7 +447,7 @@ sub import {
 
             # File is newer or a different size
             $guard ||= cPanel::StateFile::Guard->new( { state => $self } );
-            $guard->_open('+<');
+            $guard->_open();
             $self->{data_object}->load_from_cache( $self->{file_handle} );
             ( $self->{file_mtime}, $self->{file_size} ) = ( stat( $self->{file_handle} ) )[ 9, 7 ];
         }

--- a/lib/cPanel/StateFile.pm
+++ b/lib/cPanel/StateFile.pm
@@ -238,7 +238,6 @@ sub import {
                 my $fh_inode = (stat $fh)[1];
                 my $path_inode = (stat $state_file->{file_name})[1];
                 if ($fh_inode != $path_inode) {
-                    #print STDERR "redoing ($fh_inode != $path_inode)\n";
                     redo OPEN_FLOCK;
                 }
 
@@ -287,6 +286,9 @@ sub import {
             require File::Temp;
             my ($fh, $path) = File::Temp::tempfile( DIR => $self->{_file_dir}, UNLINK => 1 );
 
+            #We lock the temp file so that it’s “pre-locked”
+            #when we rename() it into place below. That way the
+            #production path stays consistently locked.
             $self->_flock_after_open($fh);
 
             $state_file->{data_object}->save_to_cache( $fh );

--- a/t/statefile_lock_replace.t
+++ b/t/statefile_lock_replace.t
@@ -1,0 +1,143 @@
+#!/usr/bin/perl
+
+use Test::More tests => 1;
+
+use strict;
+use warnings;
+use autodie;
+
+use Fcntl ();
+use File::Temp ();
+use File::Slurp ();
+use Time::HiRes ();
+
+use cPanel::StateFile ();
+
+my $dir = File::Temp::tempdir( CLEANUP => 1 );
+
+my $file_path = "$dir/the_file";
+
+our $suffix = substr( rand, 2 );
+
+#----------------------------------------------------------------------
+# This is a deep test of object internals. For conciseness,
+# it recreates objects directly rather than via constructors.
+# This is generally bad practice, but the alternatives would be either
+# an unwieldy, brittle test or a significant refactor, neither of which
+# seems justified here. (Even these tests are more complicated than
+# would be ideal.)
+#
+# Unfortunately, it means that any change to the implementation of
+# cPanel::StateFile or cPanel::StateFile::Guard is not unlikely to
+# cause a spurious failure here.
+#----------------------------------------------------------------------
+
+my $data_obj = bless( {}, 'MockDataObject' );
+
+sub _create_hack_guard {
+    my $hack_state = bless {
+        data_object => $data_obj,
+        file_name => $file_path,
+        flock_timeout => 60,
+    }, 'cPanel::StateFile';
+
+    return bless {
+        state_file => $hack_state,
+        lock_file => 'this_does_not_really_exist',
+    }, 'cPanel::StateFile::Guard';
+}
+
+#----------------------------------------------------------------------
+
+local $SIG{'CHLD'} = 'IGNORE';
+
+my $renamer_pid = fork or do {
+    alarm 30;
+    while (1) {
+        open my $fh, '>>', $file_path;
+        flock $fh, Fcntl::LOCK_EX();
+
+        do { open my $fh, '>>', "$file_path.tmp" };
+
+        Time::HiRes::sleep(0.01);
+
+        rename "$file_path.tmp" => $file_path;
+    }
+};
+
+for my $iteration ( 1 .. 10 ) {
+    note "_open() iteration $iteration …";
+
+    my $hguard = _create_hack_guard();
+    $hguard->_open();
+
+    my $fh_inode = (stat $hguard->{'state_file'}{'file_handle'})[1];
+    my $path_inode = (stat $hguard->{'state_file'}{'file_name'})[1];
+    if ($fh_inode != $path_inode) {
+        die "_open() did flock() a file handle that isn’t the path!";
+    }
+}
+
+kill 'KILL', $renamer_pid;
+
+#----------------------------------------------------------------------
+
+_create_hack_guard()->update_file();
+
+for my $iteration ( 1 .. 20 ) {
+    $suffix = substr( rand, 2 );
+    $suffix = substr( $suffix, 0, int rand length $suffix );
+
+    note "Integrity test: running iteration $iteration …";
+
+    my $expected_content = qr<\APID [0-9]+-$suffix\z>;
+
+    my $check_content_cr = sub {
+        my $content = File::Slurp::read_file($file_path);
+
+        if ( $content !~ $expected_content ) {
+            die "FAIL: content “$content” doesn’t match expected “$expected_content”";
+        }
+    };
+
+    my $pid = fork or do {
+        alarm 30;
+        my $hack_guard = _create_hack_guard();
+        $hack_guard->update_file();
+        do { open my $fh, '>', "$dir/wrote-$iteration" };
+        $hack_guard->update_file() while 1;
+    };
+
+    Time::HiRes::sleep(0.01) while !-e "$dir/wrote-$iteration";
+
+    my $start = time;
+    $check_content_cr->() while time < ($start + 1);
+
+    kill 'KILL', $pid;
+
+    $check_content_cr->();
+}
+
+ok 1, 'Done';
+
+#----------------------------------------------------------------------
+
+package MockDataObject;
+
+sub load_from_cache {
+    my ($self, $fh) = @_;
+
+    sysread( $fh, $self->{'_content'}, 32768 );
+
+    return;
+}
+
+sub save_to_cache {
+    my ($self, $fh) = @_;
+
+    syswrite( $fh, "PID $$-$main::suffix" );
+
+    return;
+}
+
+1;

--- a/t/statefile_lock_replace.t
+++ b/t/statefile_lock_replace.t
@@ -6,8 +6,8 @@ use strict;
 use warnings;
 use autodie;
 
-use Fcntl ();
-use File::Temp ();
+use Fcntl       ();
+use File::Temp  ();
 use File::Slurp ();
 use Time::HiRes ();
 
@@ -36,15 +36,17 @@ my $data_obj = bless( {}, 'MockDataObject' );
 
 sub _create_hack_guard {
     my $hack_state = bless {
-        data_object => $data_obj,
-        file_name => $file_path,
+        data_object   => $data_obj,
+        file_name     => $file_path,
         flock_timeout => 60,
-    }, 'cPanel::StateFile';
+      },
+      'cPanel::StateFile';
 
     return bless {
         state_file => $hack_state,
-        lock_file => 'this_does_not_really_exist',
-    }, 'cPanel::StateFile::Guard';
+        lock_file  => 'this_does_not_really_exist',
+      },
+      'cPanel::StateFile::Guard';
 }
 
 #----------------------------------------------------------------------
@@ -71,9 +73,9 @@ for my $iteration ( 1 .. 10 ) {
     my $hguard = _create_hack_guard();
     $hguard->_open();
 
-    my $fh_inode = (stat $hguard->{'state_file'}{'file_handle'})[1];
-    my $path_inode = (stat $hguard->{'state_file'}{'file_name'})[1];
-    if ($fh_inode != $path_inode) {
+    my $fh_inode   = ( stat $hguard->{'state_file'}{'file_handle'} )[1];
+    my $path_inode = ( stat $hguard->{'state_file'}{'file_name'} )[1];
+    if ( $fh_inode != $path_inode ) {
         die "_open() did flock() a file handle that isn’t the path!";
     }
 }
@@ -111,7 +113,7 @@ for my $iteration ( 1 .. 20 ) {
     Time::HiRes::sleep(0.01) while !-e "$dir/wrote-$iteration";
 
     my $start = time;
-    $check_content_cr->() while time < ($start + 1);
+    $check_content_cr->() while time < ( $start + 1 );
 
     kill 'KILL', $pid;
 
@@ -125,7 +127,7 @@ ok 1, 'Done';
 package MockDataObject;
 
 sub load_from_cache {
-    my ($self, $fh) = @_;
+    my ( $self, $fh ) = @_;
 
     sysread( $fh, $self->{'_content'}, 32768 );
 
@@ -133,7 +135,7 @@ sub load_from_cache {
 }
 
 sub save_to_cache {
-    my ($self, $fh) = @_;
+    my ( $self, $fh ) = @_;
 
     syswrite( $fh, "PID $$-$main::suffix" );
 

--- a/t/taskqueue_processor_checked_system.t
+++ b/t/taskqueue_processor_checked_system.t
@@ -44,7 +44,7 @@ $logger->clear();
     open STDERR, '>', '/dev/null' or die "Unable to redirect STDERR: $!";
     is( $proc->checked_system( { logger => $logger, name => 'foobarxyzzy', cmd => 'foobarxyzzy' } ), -1, 'Program cannot run' );
     is( $logger->get_message, 'WARN:Failed to run foobarxyzzy', 'Warning detected.' );
-    open STDERR, '>', $olderr;
+    open STDERR, '>&=', $olderr;
 }
 
 $logger->clear();


### PR DESCRIPTION
This makes all writes to the task queue files atomic, which ensures that power failures and such don’t corrupt the datastores.