### PR TITLE
Avoid duplicates when transferring items to the processing queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.build
 /cPanel-TaskQueue-*
+*.bak

--- a/bin/taskqueued
+++ b/bin/taskqueued
@@ -11,22 +11,22 @@ use cPanel::TaskQueue                ();
 use cPanel::TaskQueue::Scheduler     ();
 use cPanel::TaskQueue::PluginManager ();
 use Getopt::Long;
-use Unix::PID                      0.21;
-use POSIX                            ();
-use File::Spec                       ();
+use Unix::PID 0.21;
+use POSIX      ();
+use File::Spec ();
 
 main() unless caller;
 
 sub main {
-    my $queue_dir  = '.';
-    my $qname      = 'main';
+    my $queue_dir = '.';
+    my $qname     = 'main';
     my $sname;
     my $plugindirs = [];
     my $namespaces = [];
     my $plugins    = [];
     my $logfile;
 
-    handle_config_file( 'taskqueue.cfg' );
+    handle_config_file('taskqueue.cfg');
 
     GetOptions(
         'dir=s',        \$queue_dir,
@@ -42,8 +42,8 @@ sub main {
     die "Missing plugin directories.\n" unless @{$plugindirs};
 
     # Make directories absolute.
-    $plugindirs = [ map {  File::Spec->rel2abs( $_ ) } @{$plugindirs} ];
-    $queue_dir = File::Spec->rel2abs( $queue_dir );
+    $plugindirs = [ map { File::Spec->rel2abs($_) } @{$plugindirs} ];
+    $queue_dir = File::Spec->rel2abs($queue_dir);
 
     unshift @INC, @{$plugindirs} if @{$plugindirs};
     $sname = $qname unless defined $sname;
@@ -51,26 +51,28 @@ sub main {
     # Default wait time is a tradeoff:
     #   - smaller number is more responsive at picking up new tasks
     #   - larger number uses less CPU while waiting for something to happen.
-    my $wait_time = 30;
+    my $wait_time  = 30;
     my $is_running = 1;
-    my $pidobj = Unix::PID->new({ use_open3 => 0 });
-    my $pid_file = $queue_dir . '/taskqueued.pid';
+    my $pidobj     = Unix::PID->new( { use_open3 => 0 } );
+    my $pid_file   = $queue_dir . '/taskqueued.pid';
 
     $SIG{'HUP'} = sub { $is_running = 0; };
     $SIG{'CHLD'} = \&reaper;
 
     # Daemon startup
     print "==> TaskQueue Processing Daemon started\n";
-    exit if ( my $pid = fork() ); # Background myself.
+    exit if ( my $pid = fork() );    # Background myself.
     die "Failed to fork TaskQueue Processing Daemon\n" unless defined $pid;
+
     # In order to remove the race condition, we need to test again after the fork.
     # This use of Unix::PID removes the race condition when creating the pidfile.
-    if ( !$pidobj->pid_file_no_unlink( $pid_file ) ) {
+    if ( !$pidobj->pid_file_no_unlink($pid_file) ) {
         print "TaskQueue Processing Daemon already running, exiting.\n";
         exit 0;
     }
+
     # Finish launching daemon.
-    chdir( '/');
+    chdir('/');
     POSIX::setsid();
     $logfile ||= "$queue_dir/${qname}_error.log";
     open( STDOUT, '>>', $logfile ) or die "Unable to open log file '$logfile': $!\n";
@@ -78,24 +80,28 @@ sub main {
 
     load_plugins( $plugindirs, $namespaces, $plugins );
 
-    my $queue = cPanel::TaskQueue->new({
-        name => $qname,
-        state_dir => $queue_dir,
-        max_running => 1,
-    });
-    my $sched = cPanel::TaskQueue::Scheduler->new({
-        name => $qname,
-        state_dir => $queue_dir,
-    });
+    my $queue = cPanel::TaskQueue->new(
+        {
+            name        => $qname,
+            state_dir   => $queue_dir,
+            max_running => 1,
+        }
+    );
+    my $sched = cPanel::TaskQueue::Scheduler->new(
+        {
+            name      => $qname,
+            state_dir => $queue_dir,
+        }
+    );
 
     my $retry_count = 0;
 
     # Processing loop
     # Each pass thru the loop will process one task (if any are available)
     #   - if any scheduled tasks are ready to go into the queue, we do that first
-    while ( $is_running ) {
+    while ($is_running) {
         eval {
-            $sched->process_ready_tasks( $queue );
+            $sched->process_ready_tasks($queue);
             if ( $queue->has_work_to_do() ) {
                 $queue->process_next_task();
             }
@@ -108,18 +114,19 @@ sub main {
             }
             $retry_count = 0;
         };
-        if ( $@ ) {
+        if ($@) {
             warn "Exception detected: $@";
             if ( $retry_count++ > 5 ) {
                 warn "Maximum exception count reached. Shutting down taskqueued.";
                 last;
             }
+
             # pause to allow situation to recover
             sleep 15;
         }
     }
 
-    unlink $pid_file if $$ == $pidobj->get_pid_from_pidfile( $pid_file ) || !$pidobj->is_pidfile_running( $pid_file );
+    unlink $pid_file if $$ == $pidobj->get_pid_from_pidfile($pid_file) || !$pidobj->is_pidfile_running($pid_file);
 
     exit 0;
 }
@@ -140,10 +147,10 @@ sub reaper {
 }
 
 sub load_plugins {
-    my ($plugindirs, $namespaces, $plugins) = @_;
+    my ( $plugindirs, $namespaces, $plugins ) = @_;
     if ( @{$plugins} ) {
         foreach my $modname ( @{$plugins} ) {
-            cPanel::TaskQueue::PluginManager::load_plugin_by_name( $modname );
+            cPanel::TaskQueue::PluginManager::load_plugin_by_name($modname);
         }
     }
     else {
@@ -160,7 +167,7 @@ sub handle_config_file {
         $config = $1;
         shift @ARGV;
     }
-    unshift @ARGV, config_file( $config ) if -e $config;
+    unshift @ARGV, config_file($config) if -e $config;
 }
 
 sub config_file {

--- a/bin/taskqueuerun
+++ b/bin/taskqueuerun
@@ -15,15 +15,15 @@ use Getopt::Long;
 main() unless caller;
 
 sub main {
-    my $queue_dir  = '.';
-    my $qname      = 'main';
+    my $queue_dir = '.';
+    my $qname     = 'main';
     my $sname;
     my $plugindirs = [];
     my $namespaces = [];
     my $plugins    = [];
     my $logfile;
 
-    handle_config_file( 'taskqueue.cfg' );
+    handle_config_file('taskqueue.cfg');
 
     GetOptions(
         'dir=s',        \$queue_dir,
@@ -32,7 +32,7 @@ sub main {
         'plugindir=s@', \$plugindirs,
         'namespace=s@', \$namespaces,
         'plugin=s@',    \$plugins,
-        'logfile=s',    \$logfile,     # keep config file compatible between tools.
+        'logfile=s',    \$logfile,      # keep config file compatible between tools.
     );
 
     $namespaces = [ 'cPanel::TaskProcessors', ] unless @{$namespaces};
@@ -42,18 +42,22 @@ sub main {
 
     load_plugins( $plugindirs, $namespaces, $plugins );
 
-    my $queue = cPanel::TaskQueue->new({
-        name => $qname,
-        state_dir => $queue_dir,
-        max_running => 1,
-    });
-    my $sched = cPanel::TaskQueue::Scheduler->new({
-        name => $qname,
-        state_dir => $queue_dir,
-    });
+    my $queue = cPanel::TaskQueue->new(
+        {
+            name        => $qname,
+            state_dir   => $queue_dir,
+            max_running => 1,
+        }
+    );
+    my $sched = cPanel::TaskQueue::Scheduler->new(
+        {
+            name      => $qname,
+            state_dir => $queue_dir,
+        }
+    );
 
     eval {
-        my $cnt = $sched->process_ready_tasks( $queue );
+        my $cnt = $sched->process_ready_tasks($queue);
         print "$cnt scheduled tasks moved to queue.\n" if $cnt;
         if ( $queue->has_work_to_do() ) {
             $queue->process_next_task();
@@ -71,10 +75,10 @@ sub main {
 }
 
 sub load_plugins {
-    my ($plugindirs, $namespaces, $plugins) = @_;
+    my ( $plugindirs, $namespaces, $plugins ) = @_;
     if ( @{$plugins} ) {
         foreach my $modname ( @{$plugins} ) {
-            cPanel::TaskQueue::PluginManager::load_plugin_by_name( $modname );
+            cPanel::TaskQueue::PluginManager::load_plugin_by_name($modname);
         }
     }
     else {
@@ -91,7 +95,7 @@ sub handle_config_file {
         $config = $1;
         shift @ARGV;
     }
-    unshift @ARGV, config_file( $config ) if -e $config;
+    unshift @ARGV, config_file($config) if -e $config;
 }
 
 sub config_file {

--- a/lib/cPanel/TaskQueue.pm
+++ b/lib/cPanel/TaskQueue.pm
@@ -105,11 +105,11 @@ my $taskqueue_uuid = 'TaskQueue';
 
 # Class-wide definition of the valid processors
 my %valid_processors;
-END { undef %valid_processors } # case CPANEL-10871 to avoid a SEGV during global destruction
+END { undef %valid_processors }    # case CPANEL-10871 to avoid a SEGV during global destruction
 
 {
-   my $FILETYPE      = 'TaskQueue';    # Identifier at the beginning of the state file
-   my $CACHE_VERSION = 3;              # Cache file version number.
+    my $FILETYPE      = 'TaskQueue';    # Identifier at the beginning of the state file
+    my $CACHE_VERSION = 3;              # Cache file version number.
 
     # State File
     #
@@ -407,8 +407,9 @@ END { undef %valid_processors } # case CPANEL-10871 to avoid a SEGV during globa
 
             if ( $self->_add_task_to_waiting_queue($task) ) {
                 push @uuids, $task->uuid();
-            } else {
-                push @uuids, undef; # failed task
+            }
+            else {
+                push @uuids, undef;    # failed task
             }
         }
 
@@ -718,7 +719,8 @@ END { undef %valid_processors } # case CPANEL-10871 to avoid a SEGV during globa
     }
 
     sub _get_task_processor_for_task_or_throw {
-        my($self, $task) = @_;
+        my ( $self, $task ) = @_;
+
         # Validate the incoming task.
         # It must be a command we recognize, have valid parameters, and not be a duplicate.
         my $proc = _get_task_processor($task);
@@ -744,6 +746,7 @@ END { undef %valid_processors } # case CPANEL-10871 to avoid a SEGV during globa
         my $guard = $self->{disk_state}->synch();
 
         $self->_add_task_to_waiting_queue($task) or return;
+
         # Changes to the queue are complete, save to disk.
         $guard->update_file();
 

--- a/lib/cPanel/TaskQueue/Ctrl.pm
+++ b/lib/cPanel/TaskQueue/Ctrl.pm
@@ -436,7 +436,7 @@ sub convert_state_files {
         return;
     }
     my $new_serial = $format{$fmt};
-    eval "use $new_serial;";  ## no critic(ProhibitStringyEval)
+    eval "use $new_serial;";    ## no critic(ProhibitStringyEval)
     die "Unable to load serializer module '$new_serial': $@" if $@;
     _convert_a_state_file( $queue, $new_serial );
     _convert_a_state_file( $sched, $new_serial );
@@ -466,9 +466,10 @@ sub _convert_a_state_file {
 sub display_queue_info {
     my ( $ctrl, $fh, $queue, $sched, @args ) = @_;
     print $fh "Current TaskQueue Information\n";
-    my $description = $ctrl->{serial}
-                    ? "$ctrl->{serial} (".$format{lc $ctrl->{serial}}.")"
-                    : 'default';
+    my $description =
+      $ctrl->{serial}
+      ? "$ctrl->{serial} (" . $format{ lc $ctrl->{serial} } . ")"
+      : 'default';
     print $fh "Serializer:     $description\n";
     print $fh "TaskQueue file: ", $queue->_state_file(), "\n";
     print $fh "Scheduler file: ", $sched->_state_file(), "\n";
@@ -510,7 +511,7 @@ sub process_one_step {
 sub flush_scheduled_tasks {
     my ( $ctrl, $fh, $queue, $sched, @args ) = @_;
     my @ids = $sched->flush_all_tasks();
-    if(@ids) {
+    if (@ids) {
         print $fh scalar(@ids), " tasks flushed\n";
     }
     else {
@@ -523,13 +524,13 @@ sub delete_unprocessed_tasks {
     my ( $ctrl, $fh, $queue, $sched, @args ) = @_;
     @args = qw/waiting scheduled/ unless @args;
     my $count = 0;
-    if( _any_is( 'scheduled', @args ) ) {
+    if ( _any_is( 'scheduled', @args ) ) {
         $count += $sched->delete_all_tasks();
     }
-    if( _any_is( 'waiting', @args ) ) {
+    if ( _any_is( 'waiting', @args ) ) {
         $count += $queue->delete_all_unprocessed_tasks();
     }
-    if($count) {
+    if ($count) {
         print $fh "$count tasks deleted\n";
     }
     else {

--- a/lib/cPanel/TaskQueue/Scheduler.pm
+++ b/lib/cPanel/TaskQueue/Scheduler.pm
@@ -205,7 +205,7 @@ my $tasksched_uuid = 'TaskQueue-Scheduler';
         local $/;
         my ( $magic, $version, $meta ) = $self->_serializer()->load($fh);
 
-        $self->throw("Not a recognized TaskQueue Scheduler state file.\n")   unless defined $magic   and $magic   eq $FILETYPE;
+        $self->throw("Not a recognized TaskQueue Scheduler state file.\n")   unless defined $magic   and $magic eq $FILETYPE;
         $self->throw("Invalid version of TaskQueue Scheduler state file.\n") unless defined $version and $version eq $CACHE_VERSION;
 
         # Next id should continue increasing.
@@ -374,7 +374,7 @@ my $tasksched_uuid = 'TaskQueue-Scheduler';
         };
         my $ex = $@;
         $guard->update_file() if $count && $guard;
-        $self->throw( $ex ) if $ex;
+        $self->throw($ex) if $ex;
 
         return $count;
     }
@@ -402,15 +402,15 @@ my $tasksched_uuid = 'TaskQueue-Scheduler';
         };
         my $ex = $@;
         $guard->update_file() if @ids;
-        $self->throw( $ex ) if $ex;
+        $self->throw($ex) if $ex;
 
         return @ids;
     }
 
     sub delete_all_tasks {
         my ($self) = @_;
-        my $guard = $self->{disk_state}->synch();
-        my $count = @{ $self->{time_queue} };
+        my $guard  = $self->{disk_state}->synch();
+        my $count  = @{ $self->{time_queue} };
         $self->{time_queue} = [];
         $guard->update_file() if $count;
 
@@ -428,11 +428,7 @@ my $tasksched_uuid = 'TaskQueue-Scheduler';
 
         $self->{disk_state}->synch();
 
-        return [
-            map {
-                { time => $_->{time}, task => $_->{task}->clone() }
-            } @{ $self->{time_queue} }
-        ];
+        return [ map { { time => $_->{time}, task => $_->{task}->clone() } } @{ $self->{time_queue} } ];
     }
 
     # ---------------------------------------------------------------

--- a/t/mocks/MockCacheable.pm
+++ b/t/mocks/MockCacheable.pm
@@ -7,12 +7,12 @@ our $VERSION = '0.0.3';
 
 sub new {
     my $class = shift;
-    return bless { save_called=>0, load_called=>0 }, $class;
+    return bless { save_called => 0, load_called => 0 }, $class;
 }
 
 sub load_from_cache {
     my $self = shift;
-    my $fh = shift;
+    my $fh   = shift;
 
     $self->{load_called}++;
     $self->{data} = <$fh>;
@@ -20,7 +20,7 @@ sub load_from_cache {
 
 sub save_to_cache {
     my $self = shift;
-    my $fh = shift;
+    my $fh   = shift;
 
     $self->{save_called}++;
     print $fh "Save string: @{[ @$self{'save_called', 'load_called'} ]}";

--- a/t/mocks/MockQueue.pm
+++ b/t/mocks/MockQueue.pm
@@ -9,7 +9,7 @@ sub new {
 }
 
 sub queue_task {
-    my ($self, $task) = @_;
+    my ( $self, $task ) = @_;
 
     push @{$self}, $task;
     return $task->uuid;

--- a/t/mocks/cPanel/ExampleTasks/Goodbye.pm
+++ b/t/mocks/cPanel/ExampleTasks/Goodbye.pm
@@ -3,11 +3,12 @@ package cPanel::ExampleTasks::Goodbye;
 # Fake Task processing plugin designed to verify module loading.
 
 {
+
     package cPanel::ExampleTasks::Farewell;
     use base 'cPanel::TaskQueue::ChildProcessor';
 
     sub _do_child_task {
-        my ($self, $task) = @_;
+        my ( $self, $task ) = @_;
 
         my @args = $task->args();
         if ( 1 == @args ) {
@@ -15,7 +16,7 @@ package cPanel::ExampleTasks::Goodbye;
             sleep 2;
             return;
         }
-        foreach my $friend ( @args ) {
+        foreach my $friend (@args) {
             print "Farewell, $friend.\n";
             sleep 1;
         }
@@ -26,7 +27,7 @@ package cPanel::ExampleTasks::Goodbye;
 
 sub to_register {
     return (
-        [ 'bye', sub { print "Goodbye, @_\n" }, ],
+        [ 'bye',   sub { print "Goodbye, @_\n" }, ],
         [ 'adios', cPanel::ExampleTasks::Farewell->new() ],
     );
 }

--- a/t/mocks/cPanel/ExampleTasks/Greetings.pm
+++ b/t/mocks/cPanel/ExampleTasks/Greetings.pm
@@ -3,8 +3,9 @@ package cPanel::ExampleTasks::Greetings;
 # Fake Task processing plugin designed to verify module loading.
 
 sub to_register {
-    return ( [ 'helloworld', sub { local $|=1; print "Hello, World\n"; }, ],
-             [ 'hello', sub { local $|=1; print "Hello, @_\n"; sleep 1; }, ],
+    return (
+        [ 'helloworld', sub { local $| = 1; print "Hello, World\n"; }, ],
+        [ 'hello', sub { local $| = 1; print "Hello, @_\n"; sleep 1; }, ],
     );
 }
 

--- a/t/mocks/cPanel/FakeLogger.pm
+++ b/t/mocks/cPanel/FakeLogger.pm
@@ -17,32 +17,31 @@ sub reset_msgs {
 
 sub get_msgs {
     my ($self) = @_;
-    return @{$self->{msgs}};
+    return @{ $self->{msgs} };
 }
-
 
 sub throw {
     my $self = shift;
-    push @{$self->{msgs}}, "throw: @_";
+    push @{ $self->{msgs} }, "throw: @_";
     die @_;
 }
 
 sub warn {
     my $self = shift;
-    push @{$self->{msgs}}, "warn: @_";
+    push @{ $self->{msgs} }, "warn: @_";
     return;
 }
 
 sub info {
     my $self = shift;
-    push @{$self->{msgs}}, "info: @_";
+    push @{ $self->{msgs} }, "info: @_";
     return;
 }
 
 sub notify {
     my $self = shift;
     my $subj = shift;
-    push @{$self->{msgs}}, "notify: [$subj] @_";
+    push @{ $self->{msgs} }, "notify: [$subj] @_";
 }
 
 1;

--- a/t/mocks/cPanel/FakeTasks/B.pm
+++ b/t/mocks/cPanel/FakeTasks/B.pm
@@ -3,8 +3,9 @@ package cPanel::FakeTasks::B;
 # Fake Task processing plugin designed to verify module loading.
 
 sub to_register {
-    return ( [ 'helloworld', sub { print "Hello, World\n"; }, ],
-             [ 'hello', sub { print "Hello, @_\n" }, ],
+    return (
+        [ 'helloworld', sub { print "Hello, World\n"; }, ],
+        [ 'hello',      sub { print "Hello, @_\n" }, ],
     );
 }
 

--- a/t/mocks/cPanel/FakeTasks/BadRegister2.pm
+++ b/t/mocks/cPanel/FakeTasks/BadRegister2.pm
@@ -3,7 +3,7 @@ package cPanel::FakeTasks::BadRegister2;
 # Fake task processing plugin designed to test error handling.
 
 sub to_register {
-    return ( [ 'badcmd' ] );
+    return ( ['badcmd'] );
 }
 
 1;


### PR DESCRIPTION
We can accidentally insert duplicate items when moving from the deferred queue to the processing queue due to not checking for duplicates during that process.  The final commit in this series addresses that issue.  The first two are preparatory cleanups.