### PR TITLE
Bump version to 0.900 in preparation for release

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = cPanel-TaskQueue
-version = 0.850
+version = 0.900
 author  = cPanel, Inc. <cpan@cpanel.net>
 license = Perl_5
 copyright_holder = cPanel, Inc.


### PR DESCRIPTION
We need to do a new release, so we should bump the version number.