### PR TITLE
Don't confuse callers by returning a failure if plugin already included

### DIFF
--- a/lib/cPanel/TaskQueue/PluginManager.pm
+++ b/lib/cPanel/TaskQueue/PluginManager.pm
@@ -48,7 +48,7 @@ sub load_plugin_by_name {
     my ($modname) = @_;
 
     # Don't try to reload.
-    return if exists $plugins_list{$modname};
+    return 1 if exists $plugins_list{$modname};
 
     eval "require $modname;";    ## no critic (ProhibitStringyEval)
     if ($@) {

--- a/lib/cPanel/TaskQueue/PluginManager.pod
+++ b/lib/cPanel/TaskQueue/PluginManager.pod
@@ -91,6 +91,8 @@ directory containing the module must already be part of the Perl path.
 
 Returns a true value is successful and a false value otherwise.
 
+Also returns a true value when we have already previously included this plugin in your execution context.
+
 =item cPanel::TaskQueue::PluginManager::list_loaded_plugins()
 
 Returns a list of the names of the loaded plugins in no particular order.


### PR DESCRIPTION
It's common practice to do:

    cPanel::TaskQueue::PluginManager::load_plugin_by_name(...) or ...

And it can't reasonably be considered that skipping setup because
it is already setup is a *failure* condition.  Ergo, we make it into
a success condition.  This will fix a number of existing callers making
this assumption incorrectly.