### PR TITLE
Don't confuse callers by returning a failure if plugin already included

### DIFF
--- a/lib/cPanel/TaskQueue/PluginManager.pm
+++ b/lib/cPanel/TaskQueue/PluginManager.pm
@@ -48,7 +48,7 @@ sub load_plugin_by_name {
     my ($modname) = @_;
 
     # Don't try to reload.
-    return if exists $plugins_list{$modname};
+    return 1 if exists $plugins_list{$modname};
 
     eval "require $modname;";    ## no critic (ProhibitStringyEval)
     if ($@) {

--- a/t/taskqueue_plugin_manager_load_named.t
+++ b/t/taskqueue_plugin_manager_load_named.t
@@ -26,7 +26,7 @@ is_deeply( cPanel::TaskQueue::PluginManager::get_plugins_hash(), {}, 'No plugins
     is_deeply( $plugins, $expected, 'One module: Plugins and commands match' );
 }
 
-plugin_load_no_ok( 'cPanel::FakeTasks::B', 'Cannot reload plugin' );
+plugin_load_ok( 'cPanel::FakeTasks::B', 'Cannot reload plugin' );
 
 {
     ok( cPanel::TaskQueue::PluginManager::load_plugin_by_name('cPanel::FakeTasks::A'), 'Loaded second actual plugin' );
@@ -51,4 +51,18 @@ sub plugin_load_no_ok {
     open( STDERR, '>&', $olderr ) or die "Unable to restore STDERR: $!";
 
     ok( !$status, $name );
+}
+
+sub plugin_load_ok {
+    my ($module, $name) = @_;
+
+    # Capture STDERR so Logger doesn't go to screen.
+    open( my $olderr, '>&STDERR' ) or die "Can't dupe STDERR: $!";
+    close( STDERR ); open( STDERR, '>', '/dev/null' ) or die "Unable to redirect STDERR: $!";
+
+    my $status = cPanel::TaskQueue::PluginManager::load_plugin_by_name( $module );
+
+    open( STDERR, '>&', $olderr ) or die "Unable to restore STDERR: $!";
+
+    ok( $status, $name );
 }


### PR DESCRIPTION
Case CPANEL-22183: It's common practice to do:

    cPanel::TaskQueue::PluginManager::load_plugin_by_name(...) or ...

And it can't reasonably be considered that skipping setup because
it is already setup is a *failure* condition.  Ergo, we make it into
a success condition.  This will fix a number of existing callers making
this assumption incorrectly.

Changelog: Make plugin include return true when plugins are already
        included.