### PR TITLE
Fix exception when serializing a TaskQueue object

### DIFF
--- a/lib/cPanel/TaskQueue/Scheduler.pm
+++ b/lib/cPanel/TaskQueue/Scheduler.pm
@@ -89,6 +89,10 @@ sub _first (&@) {                                      ## no critic(ProhibitSubr
     return;
 }
 
+sub TO_JSON {
+    return { %{ $_[0] } };
+}
+
 # Namespace value used when creating unique task ids.
 my $tasksched_uuid = 'TaskQueue-Scheduler';
 

--- a/lib/cPanel/TaskQueue/Task.pm
+++ b/lib/cPanel/TaskQueue/Task.pm
@@ -229,6 +229,10 @@ sub _verify_userdata_arg {
     return;
 }
 
+sub TO_JSON {
+    return { %{ $_[0] } };
+}
+
 1;
 
 __END__

--- a/t/taskqueue_scheduler.t
+++ b/t/taskqueue_scheduler.t
@@ -12,7 +12,7 @@ use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Temp ();
 
-use Test::More tests => 93;
+use Test::More tests => 94;
 use Test::Exception;
 use cPanel::TaskQueue::Scheduler;
 use MockQueue;
@@ -134,6 +134,8 @@ while ( my $task = $sched->peek_next_task() ) {
 
 ok( $sched->schedule_task( 'noop 0', {} ), 'Scheduled with no time setting.' );
 ok( $sched->seconds_until_next_task() <= 0, 'Scheduled right now (or in the last second.' );
+
+is_deeply cPanel::TaskQueue::Scheduler::TO_JSON( {qw/a b c d/} ), { qw/a b c d/ }, "naive TO_JSON helper";
 
 {
     my $label = 'flush_all_tasks';

--- a/t/taskqueue_task.t
+++ b/t/taskqueue_task.t
@@ -7,7 +7,7 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 
-use Test::More tests => 27;
+use Test::More tests => 28;
 use cPanel::TaskQueue::Task;
 
 my $t1 = cPanel::TaskQueue::Task->new( { cmd => 'noop', id => 1, timeout => 10 } );
@@ -58,3 +58,5 @@ is( $t1->pid, $$, ' ... but I can give it one.' );
 ok( cPanel::TaskQueue::Task::is_valid_taskid( $t1->uuid() ), 'Taskid is not valid.' );
 ok( !cPanel::TaskQueue::Task::is_valid_taskid(),             'Missing taskid is not valid.' );
 ok( !cPanel::TaskQueue::Task::is_valid_taskid('fred'),       'badly formed taskid is not valid.' );
+
+is_deeply cPanel::TaskQueue::Task::TO_JSON( { 1..6} ), { 1..6 }, "naive TO_JSON helper";


### PR DESCRIPTION
If we try to dump a taskqueue object with Cpanel::JSON before loading
Cpanel::TaskQueue::Serializer it will crash because TO_JSON hasn't been
installed

(cherry picked from commit 81a2148d3087eba88146afbb9e79ce6018506c6c)
Signed-off-by: Nicolas R <atoomic@cpan.org>